### PR TITLE
fix: reconcile pod template drift; harden for production

### DIFF
--- a/charts/discord-js-kuberscaler/values.yaml
+++ b/charts/discord-js-kuberscaler/values.yaml
@@ -61,9 +61,12 @@ podAnnotations: {}
 
 podSecurityContext:
   runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
   allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
   capabilities:
     drop:
       - ALL

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -70,8 +70,10 @@ func main() {
 		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	// Default to production logging (JSON, info level). Pass --zap-devel for
+	// human-readable console output and debug-level stacktraces during development.
 	opts := zap.Options{
-		Development: true,
+		Development: false,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
@@ -127,7 +129,7 @@ func main() {
 		WebhookServer:          webhookServer,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "551b6c3c.nerdz.io",
+		LeaderElectionID:       "discordsharder.discord.ok8.sh",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,13 +50,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -67,6 +62,7 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
             - "ALL"

--- a/internal/controller/discordsharder_controller.go
+++ b/internal/controller/discordsharder_controller.go
@@ -18,6 +18,9 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -63,6 +66,12 @@ const (
 
 	// defaultSyncInterval is used when spec.syncInterval is not set.
 	defaultSyncInterval = 12 * time.Hour
+
+	// specHashAnnotation stores a hash of the StatefulSet spec the operator last
+	// applied. It lets the controller detect drift in any managed field (replica
+	// count, pod template, update strategy) with a single comparison instead of a
+	// brittle field-by-field diff against an API-server-defaulted object.
+	specHashAnnotation = "discord.ok8.sh/spec-hash"
 )
 
 // DiscordSharderReconciler reconciles a DiscordSharder object
@@ -481,23 +490,40 @@ func (r *DiscordSharderReconciler) ensureStatefulSet(ctx context.Context, gatewa
 		return fmt.Errorf("failed to set owner reference: %w", err)
 	}
 
-	existingSts := &appsv1.StatefulSet{}
-	err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: gateway.Namespace}, existingSts)
+	// Stamp a hash of the desired spec so future reconciles can detect drift in
+	// any managed field — not just the replica count.
+	hash, err := specHash(desiredSts)
+	if err != nil {
+		return fmt.Errorf("failed to hash StatefulSet spec: %w", err)
+	}
+	if desiredSts.Annotations == nil {
+		desiredSts.Annotations = make(map[string]string)
+	}
+	desiredSts.Annotations[specHashAnnotation] = hash
 
-	if err != nil && apierrors.IsNotFound(err) {
+	existingSts := &appsv1.StatefulSet{}
+	getErr := r.Get(ctx, types.NamespacedName{Name: name, Namespace: gateway.Namespace}, existingSts)
+
+	if getErr != nil && apierrors.IsNotFound(getErr) {
 		logger.Info("Creating StatefulSet", "name", name, "replicas", replicas)
 		if createErr := r.Create(ctx, desiredSts); createErr != nil {
 			return fmt.Errorf("failed to create StatefulSet: %w", createErr)
 		}
 		return nil
-	} else if err != nil {
-		return fmt.Errorf("failed to get StatefulSet: %w", err)
+	} else if getErr != nil {
+		return fmt.Errorf("failed to get StatefulSet: %w", getErr)
 	}
 
-	// Sync all mutable fields if the replica count has drifted.
-	if existingSts.Spec.Replicas == nil || *existingSts.Spec.Replicas != replicas {
+	// Sync all mutable fields if the desired spec has drifted from what we last
+	// applied. This propagates pod template changes (image, resources, env, …)
+	// as well as replica count changes.
+	if existingSts.Annotations[specHashAnnotation] != hash {
 		logger.Info("Updating StatefulSet", "name", name, "replicas", replicas)
 		existingSts.Labels = desiredSts.Labels
+		if existingSts.Annotations == nil {
+			existingSts.Annotations = make(map[string]string)
+		}
+		existingSts.Annotations[specHashAnnotation] = hash
 		existingSts.Spec.Replicas = desiredSts.Spec.Replicas
 		existingSts.Spec.Template = desiredSts.Spec.Template
 		existingSts.Spec.UpdateStrategy = desiredSts.Spec.UpdateStrategy
@@ -508,6 +534,18 @@ func (r *DiscordSharderReconciler) ensureStatefulSet(ctx context.Context, gatewa
 	}
 
 	return nil
+}
+
+// specHash returns a stable hex-encoded SHA-256 of the StatefulSet's spec. It is
+// used to detect whether the operator-managed spec has drifted from what was last
+// applied without diffing against an API-server-defaulted object field by field.
+func specHash(sts *appsv1.StatefulSet) (string, error) {
+	data, err := json.Marshal(sts.Spec)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
 }
 
 // activeSTSName returns the name of the currently active StatefulSet.

--- a/internal/controller/discordsharder_controller_test.go
+++ b/internal/controller/discordsharder_controller_test.go
@@ -161,6 +161,35 @@ var _ = Describe("DiscordSharder Controller", func() {
 			Expect(gw.Status.AppliedShards).To(Equal(int32(3)))
 		})
 
+		It("should propagate pod template changes to the StatefulSet when the shard count is unchanged", func() {
+			By("Reconciling to create the initial StatefulSet")
+			controllerReconciler := &DiscordSharderReconciler{
+				Client:        k8sClient,
+				Scheme:        k8sClient.Scheme(),
+				DiscordClient: discord.NewMockClient(),
+			}
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			sts := &appsv1.StatefulSet{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, sts)).To(Succeed())
+			Expect(sts.Spec.Template.Spec.Containers[0].Image).To(Equal("test:latest"))
+
+			By("Changing the container image in the DiscordSharder template (same shard count)")
+			gw := &discordv1alpha1.DiscordSharder{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, gw)).To(Succeed())
+			gw.Spec.Template.Spec.Containers[0].Image = "test:v2"
+			Expect(k8sClient.Update(ctx, gw)).To(Succeed())
+
+			By("Reconciling again")
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the StatefulSet pod template image was updated")
+			Expect(k8sClient.Get(ctx, typeNamespacedName, sts)).To(Succeed())
+			Expect(sts.Spec.Template.Spec.Containers[0].Image).To(Equal("test:v2"))
+		})
+
 		It("should reject an invalid sharding config where minShards exceeds maxShards", func() {
 			By("Creating a DiscordSharder with minShards > maxShards")
 			invalidName := "invalid-sharding"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -201,7 +201,8 @@ var _ = Describe("Manager", Ordered, func() {
 				cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(ContainSubstring("controller-runtime.metrics\tServing metrics server"),
+				g.Expect(output).To(ContainSubstring(
+					`"logger":"controller-runtime.metrics","msg":"Serving metrics server"`),
 					"Metrics server not yet started")
 			}
 			Eventually(verifyMetricsServerStarted).Should(Succeed())


### PR DESCRIPTION
## Summary

- **Fix a real reconcile bug:** the StatefulSet reconciler only updated when the replica count changed, so pod template changes (image, resources, env vars) were silently ignored. Now drift in any managed field is detected via a spec-hash annotation (`discord.ok8.sh/spec-hash`, SHA-256 of the StatefulSet spec), so template changes roll out too.
- **Production logging:** default the zap logger to production (JSON / info level) instead of development mode; `--zap-devel` still enables console output locally.
- **Stale scaffold value:** set a project-appropriate `LeaderElectionID` (was `551b6c3c.nerdz.io`).
- **Security hardening:** enable `seccompProfile: RuntimeDefault` and `readOnlyRootFilesystem: true` in the manager manifest and Helm chart.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l` all clean
- `go test ./internal/...` passes, including a new regression test that changes the container image with an unchanged shard count and asserts the rollout happens (this test fails against the old replica-only check)
- `helm template charts/discord-js-kuberscaler` renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)